### PR TITLE
Bug - Remove ", USA" from AQI location string

### DIFF
--- a/modules/air_quality.py
+++ b/modules/air_quality.py
@@ -73,7 +73,8 @@ class AirQuality(BotModule):
             return
         summary = "Air Quality"
         if air_quality.city is not None and air_quality.city.name is not None:
-            summary += f" in {air_quality.city.name}:"
+            location = air_quality.city.name.removesuffix(", USA")
+            summary += f" in {location}:"
         else:
             summary += ":"
         if air_quality.aqi is not None:

--- a/modules/local_aqi_alerts.py
+++ b/modules/local_aqi_alerts.py
@@ -84,7 +84,8 @@ class AirQualityChecker(BotModule):
         aqi_emoji = self.api_service.get_aqi_emoji(data.aqi)
         summary = "Air Quality Alert: "
         if data.city is not None and data.city.name is not None:
-            summary = f"Air Quality Alert for {data.city.name}: "
+            location = data.city.name.removesuffix(", USA")
+            summary = f"Air Quality Alert for {location}: "
         summary += f"{aqi_emoji} {aqi_description} {data.aqi}"
         if data.forecast is not None and data.forecast.daily is not None:
             forecast_summary = self.api_service.get_todays_forecast_summary(


### PR DESCRIPTION
This PR is a simple tweak to the AQI command and monitor module. It removes the ", USA" from the end of the location if present (to save a little character space in the message).